### PR TITLE
WebAudio対応

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -4,6 +4,7 @@ function($scope, $location, $timeout, GeneratorService) {
 
   $scope.p = {inputText: ''};
   $scope.generatedMml = "なし";
+  $scope.mmlFormat = "sion";
 
 
   // URLから取得 [用途] URLだけでMMLを受け取れるようにする
@@ -29,8 +30,7 @@ function($scope, $location, $timeout, GeneratorService) {
     if (!paramFromUrl) return undefined;
     return JSON.parse(lzbase62.decompress(paramFromUrl));
   }
-
-
+  
   $scope.openTweet = function() {
     var twUrl = "https://twitter.com/intent/tweet?";
     var prms = "";
@@ -41,15 +41,27 @@ function($scope, $location, $timeout, GeneratorService) {
       );
     window.open(twUrl + prms, "", "scrollbars=yes,width=500,height=300");
   };
-
-
+  
   $scope.generate = function() {
     $timeout(function() { // compileより前にする(compileがSIOPMロード失敗の為にundefinedでexceptionになっても、先にURLへの反映はしておく)
       setParamsToUrlFromScope();
     }, 0);
 
     $scope.generatedMml = $scope.p.inputText;
-    SIOPM.compile($scope.generatedMml);
+
+    switch($scope.mmlFormat){
+      case "sion" :
+        SIOPM.stop();
+        SIOPM.compile($scope.generatedMml);
+        break;
+      case "sionic" :
+        Pico.pause();
+        Pico.play(Sionic($scope.generatedMml));
+        break;
+      default: 
+        console.error("Unsupported format");
+    }
+    
   };
 
 
@@ -70,9 +82,17 @@ function($scope, $location, $timeout, GeneratorService) {
     SIOPM.play();
   };
 
-  SIOPM.initialize(); // [前提] SIOPMのプロパティへ各functionを代入し終わっていること
+  try{
+    SIOPM.initialize(); // [前提] SIOPMのプロパティへ各functionを代入し終わっていること
+  }catch(e){
+    //fallback
+    $scope.mmlFormat = "sionic";
+  }
   $timeout(function() {
     setParamsToScopeFromUrl(); // [前提] $scopeのプロパティへ各functionを代入し終わっていること
+    if($scope.mmlFormat === "sionic"){
+      $scope.generate();
+    }
   }, 0);
 
 

--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
         ></textarea>
         <br/>
         <br/>
+        <button ng-show="isiPhone()" ng-click='play()'>再生</button>
         <button ng-click='reverseOctave()'>オクターブ上下反転</button>
-        <button ng-click='generate()'>Play</button>
         <br/>
         <br/>
         <button ng-click='openTweet()'>ツイートする</button>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     <script type='text/javascript' src='jquery.js'></script>
     <script type='text/javascript' src='siopm.js'></script>
     <script type='text/javascript' src='lzbase62.min.js'></script>
+    <script src="https://minipop.github.io/sionicjs/demo/pico.min.js"></script>
+    <script src="https://minipop.github.io/sionicjs/dist/sionic.js"></script>
 
     <style type="text/css">
     textarea {
@@ -30,14 +32,16 @@
         <br/>
         <br/>
         <button ng-click='reverseOctave()'>オクターブ上下反転</button>
+        <button ng-click='generate()'>Play</button>
         <br/>
         <br/>
         <button ng-click='openTweet()'>ツイートする</button>
       </div>
       <br/>
       <span>MMLフォーマット:
-        <select>
-          <option>SiON (すたどんたんでお馴染み)</option>
+        <select ng-model="mmlFormat" ng-change="generate()">
+          <option value="sion">SiON (すたどんたんでお馴染み)</option>
+          <option value="sionic">Pico.js + Sionic.js</option>
         </select>
       </span>
     </div>


### PR DESCRIPTION
iOS / Flash非対応環境で鳴らせるようにしてみました。

DEMO:
http://minipop.github.io/MML-editor/
- エンジン部分はmohayonaoさんの[Pico.js](https://mohayonao.github.io/pico.js/)のサンプルを切り出したものです。
- SiONと互換性はまじめにとっていません。Chord Generatorの吐いたMMLがPSGで鳴らせる程度の互換を取るためにクイックハックしてあります。
- SiONと音色に互換性はありません。
- iOSの制約により、再生ボタンを設けてあります。
